### PR TITLE
#93 re-attempts functionality on hold  , close #98 fixed

### DIFF
--- a/src/classmentors/components/challenges/mcq/mcq-view-mcq-edit.html
+++ b/src/classmentors/components/challenges/mcq/mcq-view-mcq-edit.html
@@ -8,66 +8,67 @@
             <br><br>
         </div>
 
-        <div>
-            <md-input-container>
-                *Time Limit (in minute)
-                <input type="number" name="editTimeLimit" id="edit-time-limit"
-                       ng-model="ctrl.task.timeLimit"
-                       min="0" step="1"
-                       placeholer="Time Limit for the quiz" value="" required
-                />
-                <div ng-messages="editMcq.editTimeLimit.$error">
-                    <div ng-message="number">Time limit allowed should be a positive number in minutes.</div>
-                    <div ng-message="required">Enter time limit for the quiz. </div>
-                </div>
-            </md-input-container>
+        <!--<div>-->
+        <!--todo: requires timer to enable this function.-->
+        <!--<md-input-container>-->
+        <!--*Time Limit (in minute)-->
+        <!--<input type="number" name="editTimeLimit" id="edit-time-limit"-->
+        <!--ng-model="ctrl.task.timeLimit"-->
+        <!--min="0" step="1"-->
+        <!--placeholder="Time Limit for the quiz" value="" required-->
+        <!--/>-->
+        <!--<div ng-messages="editMcq.editTimeLimit.$error">-->
+        <!--<div ng-message="number">Time limit allowed should be a positive number in minutes.</div>-->
+        <!--<div ng-message="required">Enter time limit for the quiz. </div>-->
+        <!--</div>-->
+        <!--</md-input-container>-->
 
-            <p>
-            <h5>Questions</h5>
-            <md-switch class="md-primary" ng-model="ctrl.task.randomQOrder" aria-label="">
-                Randomise questions order
-            </md-switch>
+        <!--<p>-->
+        <!--<h5>Questions</h5>-->
+        <!--<md-switch class="md-primary" ng-model="ctrl.task.randomQOrder" aria-label="">-->
+        <!--Randomise questions order-->
+        <!--</md-switch>-->
 
-            <md-switch class="md-primary" ng-model="ctrl.task.randomOOrder" aria-label="">
-                Randomise options order
-            </md-switch>
-            </p>
+        <!--<md-switch class="md-primary" ng-model="ctrl.task.randomOOrder" aria-label="">-->
+        <!--Randomise options order-->
+        <!--</md-switch>-->
+        <!--</p>-->
 
-            <h5>Results Release</h5>
-            <md-input-container>
-                *Waiting time to view result after student's completion (minutes)
-                <input type="number" name="resultRelease" id="result-release"
-                       ng-model="ctrl.task.resultRelease"
-                       min="0" step="1"
-                       placeholer="Waiting time to view result after student's completion" value="" required
-                />
-                <div ng-messages="editMcq.resultRelease.$error">
-                    <div ng-message="number">Release time after completion should be a positive number in minutes.</div>
-                    <div ng-message="required">Please enter time(minutes) to release results after completion.</div>
-                </div>
-            </md-input-container>
+        <!--<h5>Results Release</h5>-->
+        <!--<md-input-container>-->
+        <!--*Waiting time to view result after student's completion (minutes)-->
+        <!--<input type="number" name="resultRelease" id="result-release"-->
+        <!--ng-model="ctrl.task.resultRelease"-->
+        <!--min="0" step="1"-->
+        <!--placeholder="Waiting time to view result after student's completion" value="" required-->
+        <!--/>-->
+        <!--<div ng-messages="editMcq.resultRelease.$error">-->
+        <!--<div ng-message="number">Release time after completion should be a positive number in minutes.</div>-->
+        <!--<div ng-message="required">Please enter time(minutes) to release results after completion.</div>-->
+        <!--</div>-->
+        <!--</md-input-container>-->
 
-            <!--todo: install angular-timer and make timer work first before uncommenting-->
-            <!--<h5> Re-attempts Allowance</h5>-->
-            <!--<md-input-container>-->
-            <!--*Waiting time before students can re-attempt challenge (minutes)-->
-            <!--<input type="number" name="reattempts" id="reattempts"-->
-            <!--ng-model="ctrl.task.reattempts"-->
-            <!--min="0" step="1"-->
-            <!--placeholer="Waiting time before students can re-attempt challenge (minutes)" value="" required-->
-            <!--/>-->
-            <!--<div ng-messages="editMcq.reattempts.$error">-->
-            <!--<div ng-message="number">Waiting time before students can re-attempt challenge should be a positive number in minutes.</div>-->
-            <!--<div ng-message="required">Please enter time(minutes) before students can re-attempt challenge.</div>-->
-            <!--</div>-->
-            <!--</md-input-container>-->
+        <!--todo: install angular-timer and make timer work first before uncommenting-->
+        <!--<h5> Re-attempts Allowance</h5>-->
+        <!--<md-input-container>-->
+        <!--*Waiting time before students can re-attempt challenge (minutes)-->
+        <!--<input type="number" name="reattempts" id="reattempts"-->
+        <!--ng-model="ctrl.task.reattempts"-->
+        <!--min="0" step="1"-->
+        <!--placeholder="Waiting time before students can re-attempt challenge (minutes)" value="" required-->
+        <!--/>-->
+        <!--<div ng-messages="editMcq.reattempts.$error">-->
+        <!--<div ng-message="number">Waiting time before students can re-attempt challenge should be a positive number in minutes.</div>-->
+        <!--<div ng-message="required">Please enter time(minutes) before students can re-attempt challenge.</div>-->
+        <!--</div>-->
+        <!--</md-input-container>-->
 
-            <h5>Team Mode</h5>
-            <md-switch class="md-primary" ng-model="ctrl.task.enableTeam" aria-label="">
-                Enable team answering mode
-            </md-switch>
+        <!--<h5>Team Mode</h5>-->
+        <!--<md-switch class="md-primary" ng-model="ctrl.task.enableTeam" aria-label="">-->
+        <!--Enable team answering mode-->
+        <!--</md-switch>-->
 
-        </div>
+        <!--</div>-->
 
         <!------------------starting of questions--------------------------------------------->
 

--- a/src/classmentors/components/challenges/mcq/mcq-view-mcq-edit.html
+++ b/src/classmentors/components/challenges/mcq/mcq-view-mcq-edit.html
@@ -47,19 +47,20 @@
                 </div>
             </md-input-container>
 
-            <h5> Re-attempts Allowance</h5>
-            <md-input-container>
-                *Waiting time before students can re-attempt challenge (minutes)
-                <input type="number" name="reattempts" id="reattempts"
-                       ng-model="ctrl.task.reattempts"
-                       min="0" step="1"
-                       placeholer="Waiting time before students can re-attempt challenge (minutes)" value="" required
-                />
-                <div ng-messages="editMcq.reattempts.$error">
-                    <div ng-message="number">Waiting time before students can re-attempt challenge should be a positive number in minutes.</div>
-                    <div ng-message="required">Please enter time(minutes) before students can re-attempt challenge.</div>
-                </div>
-            </md-input-container>
+            <!--todo: install angular-timer and make timer work first before uncommenting-->
+            <!--<h5> Re-attempts Allowance</h5>-->
+            <!--<md-input-container>-->
+            <!--*Waiting time before students can re-attempt challenge (minutes)-->
+            <!--<input type="number" name="reattempts" id="reattempts"-->
+            <!--ng-model="ctrl.task.reattempts"-->
+            <!--min="0" step="1"-->
+            <!--placeholer="Waiting time before students can re-attempt challenge (minutes)" value="" required-->
+            <!--/>-->
+            <!--<div ng-messages="editMcq.reattempts.$error">-->
+            <!--<div ng-message="number">Waiting time before students can re-attempt challenge should be a positive number in minutes.</div>-->
+            <!--<div ng-message="required">Please enter time(minutes) before students can re-attempt challenge.</div>-->
+            <!--</div>-->
+            <!--</md-input-container>-->
 
             <h5>Team Mode</h5>
             <md-switch class="md-primary" ng-model="ctrl.task.enableTeam" aria-label="">
@@ -93,10 +94,9 @@
 
             <md-input-container >
                 <md-button type="button" class="md-raised md-primary" id="addOptions" ng-click="ctrl.addOption(question)">Add option</md-button>
-
-                    <div ng-show="ctrl.isMcqValid == false">One of the option must be an answer.</div>
-
             </md-input-container>
+
+            <p ng-show="ctrl.isMcqValid == false"><font color="red">*One of the option must be an answer.</font></p>
 
             <!--answer options-->
             <div align="center" layout="row" ng-repeat="option in question.options" >

--- a/src/classmentors/components/challenges/mcq/mcq-view-mcq.html
+++ b/src/classmentors/components/challenges/mcq/mcq-view-mcq.html
@@ -8,44 +8,45 @@
             <br><br>
         </div>
 
-        <div>
-            <md-input-container>
-                *Time Limit (in minute)
-                <input type="number" name="editTimeLimit" id="edit-time-limit"
-                       ng-model="ctrl.task.timeLimit"
-                       min="0" step="1"
-                       placeholer="Time Limit for the quiz" value="" required
-                />
-                <div ng-messages="editMcq.editTimeLimit.$error">
-                    <div ng-message="number">Time limit allowed should be a positive number in minutes.</div>
-                    <div ng-message="required">Enter time limit for the quiz. </div>
-                </div>
-            </md-input-container>
+        <!--<div>-->
+            <!--todo: requires timer to enable this function.-->
+            <!--<md-input-container>-->
+                <!--*Time Limit (in minute)-->
+                <!--<input type="number" name="editTimeLimit" id="edit-time-limit"-->
+                       <!--ng-model="ctrl.task.timeLimit"-->
+                       <!--min="0" step="1"-->
+                       <!--placeholder="Time Limit for the quiz" value="" required-->
+                <!--/>-->
+                <!--<div ng-messages="editMcq.editTimeLimit.$error">-->
+                    <!--<div ng-message="number">Time limit allowed should be a positive number in minutes.</div>-->
+                    <!--<div ng-message="required">Enter time limit for the quiz. </div>-->
+                <!--</div>-->
+            <!--</md-input-container>-->
 
-            <p>
-            <h5>Questions</h5>
-            <md-switch class="md-primary" ng-model="ctrl.task.randomQOrder" aria-label="">
-                Randomise questions order
-            </md-switch>
+            <!--<p>-->
+                <!--<h5>Questions</h5>-->
+                <!--<md-switch class="md-primary" ng-model="ctrl.task.randomQOrder" aria-label="">-->
+                    <!--Randomise questions order-->
+                <!--</md-switch>-->
 
-            <md-switch class="md-primary" ng-model="ctrl.task.randomOOrder" aria-label="">
-                Randomise options order
-            </md-switch>
-            </p>
+                <!--<md-switch class="md-primary" ng-model="ctrl.task.randomOOrder" aria-label="">-->
+                    <!--Randomise options order-->
+                <!--</md-switch>-->
+            <!--</p>-->
 
-            <h5>Results Release</h5>
-            <md-input-container>
-                *Waiting time to view result after student's completion (minutes)
-                <input type="number" name="resultRelease" id="result-release"
-                       ng-model="ctrl.task.resultRelease"
-                       min="0" step="1"
-                       placeholer="Waiting time to view result after student's completion" value="" required
-                />
-                <div ng-messages="editMcq.resultRelease.$error">
-                    <div ng-message="number">Release time after completion should be a positive number in minutes.</div>
-                    <div ng-message="required">Please enter time(minutes) to release results after completion.</div>
-                </div>
-            </md-input-container>
+            <!--<h5>Results Release</h5>-->
+            <!--<md-input-container>-->
+                <!--*Waiting time to view result after student's completion (minutes)-->
+                <!--<input type="number" name="resultRelease" id="result-release"-->
+                       <!--ng-model="ctrl.task.resultRelease"-->
+                       <!--min="0" step="1"-->
+                       <!--placeholder="Waiting time to view result after student's completion" value="" required-->
+                <!--/>-->
+                <!--<div ng-messages="editMcq.resultRelease.$error">-->
+                    <!--<div ng-message="number">Release time after completion should be a positive number in minutes.</div>-->
+                    <!--<div ng-message="required">Please enter time(minutes) to release results after completion.</div>-->
+                <!--</div>-->
+            <!--</md-input-container>-->
 
             <!--todo: install angular-timer and make timer work first before uncommenting-->
             <!--<h5> Re-attempts Allowance</h5>-->
@@ -54,7 +55,7 @@
                 <!--<input type="number" name="reattempts" id="reattempts"-->
                        <!--ng-model="ctrl.task.reattempts"-->
                        <!--min="0" step="1"-->
-                       <!--placeholer="Waiting time before students can re-attempt challenge (minutes)" value="" required-->
+                       <!--placeholder="Waiting time before students can re-attempt challenge (minutes)" value="" required-->
                 <!--/>-->
                 <!--<div ng-messages="editMcq.reattempts.$error">-->
                     <!--<div ng-message="number">Waiting time before students can re-attempt challenge should be a positive number in minutes.</div>-->
@@ -62,12 +63,12 @@
                 <!--</div>-->
             <!--</md-input-container>-->
 
-            <h5>Team Mode</h5>
-            <md-switch class="md-primary" ng-model="ctrl.task.enableTeam" aria-label="">
-                Enable team answering mode
-            </md-switch>
+            <!--<h5>Team Mode</h5>-->
+            <!--<md-switch class="md-primary" ng-model="ctrl.task.enableTeam" aria-label="">-->
+                <!--Enable team answering mode-->
+            <!--</md-switch>-->
 
-        </div>
+        <!--</div>-->
 
         <!------------------starting of questions--------------------------------------------->
 

--- a/src/classmentors/components/challenges/mcq/mcq-view-mcq.html
+++ b/src/classmentors/components/challenges/mcq/mcq-view-mcq.html
@@ -47,19 +47,20 @@
                 </div>
             </md-input-container>
 
-            <h5> Re-attempts Allowance</h5>
-            <md-input-container>
-                *Waiting time before students can re-attempt challenge (minutes)
-                <input type="number" name="reattempts" id="reattempts"
-                       ng-model="ctrl.task.reattempts"
-                       min="0" step="1"
-                       placeholer="Waiting time before students can re-attempt challenge (minutes)" value="" required
-                />
-                <div ng-messages="editMcq.reattempts.$error">
-                    <div ng-message="number">Waiting time before students can re-attempt challenge should be a positive number in minutes.</div>
-                    <div ng-message="required">Please enter time(minutes) before students can re-attempt challenge.</div>
-                </div>
-            </md-input-container>
+            <!--todo: install angular-timer and make timer work first before uncommenting-->
+            <!--<h5> Re-attempts Allowance</h5>-->
+            <!--<md-input-container>-->
+                <!--*Waiting time before students can re-attempt challenge (minutes)-->
+                <!--<input type="number" name="reattempts" id="reattempts"-->
+                       <!--ng-model="ctrl.task.reattempts"-->
+                       <!--min="0" step="1"-->
+                       <!--placeholer="Waiting time before students can re-attempt challenge (minutes)" value="" required-->
+                <!--/>-->
+                <!--<div ng-messages="editMcq.reattempts.$error">-->
+                    <!--<div ng-message="number">Waiting time before students can re-attempt challenge should be a positive number in minutes.</div>-->
+                    <!--<div ng-message="required">Please enter time(minutes) before students can re-attempt challenge.</div>-->
+                <!--</div>-->
+            <!--</md-input-container>-->
 
             <h5>Team Mode</h5>
             <md-switch class="md-primary" ng-model="ctrl.task.enableTeam" aria-label="">

--- a/src/classmentors/components/challenges/mcq/mcq-view-start.html
+++ b/src/classmentors/components/challenges/mcq/mcq-view-start.html
@@ -85,7 +85,7 @@
     <br>
 
     <div align="center">
-      <md-button type="submit" class="md-raised md-primary">Submit</md-button>
+      <md-button type="submit" ng-disabled="ctrl.isMcqValid == false" class="md-raised md-primary">Submit</md-button>
       <md-button type="reset" class="md-raised" ng-click="ctrl.discardChanges($event)">Cancel</md-button>
     </div>
     </form>

--- a/src/classmentors/components/challenges/mcq/mcq.js
+++ b/src/classmentors/components/challenges/mcq/mcq.js
@@ -202,6 +202,8 @@ export function startMcqController(initialData, challengeService, clmDataStore, 
   var quesFromJson = angular.fromJson(self.task.mcqQuestions);
   self.questions = loadQuestions(quesFromJson);
 
+  self.isMcqValid = false;
+
   function arraysEqual(arr1, arr2) {
     if(arr1.length !== arr2.length)
       return 0;
@@ -231,24 +233,22 @@ export function startMcqController(initialData, challengeService, clmDataStore, 
   };
 
   self.submit = function(){
-    var submission = {};
-    var userAnswers = [];
-    for(var i = 0; i < self.questions.length; i++){
-      userAnswers.push(self.questions[i].answers);
-    }
-    submission.userAnswers = userAnswers;
-    var score = markQuestions(userAnswers);
-    console.log(submission.score);
-    var answerString = angular.toJson(submission);
-    console.log(answerString);
-    clmDataStore.events.submitSolution(eventId, taskId, participant.$id, answerString)
-      .then(
-        clmDataStore.events.saveScore(eventId, participant.$id, taskId, score)
-      ).then(
-      $location.path(urlFor('oneEvent',{eventId: eventId}))
-    );
-
-
+      var submission = {};
+      var userAnswers = [];
+      for(var i = 0; i < self.questions.length; i++){
+        userAnswers.push(self.questions[i].answers);
+      }
+      submission.userAnswers = userAnswers;
+      var score = markQuestions(userAnswers);
+      console.log(submission.score);
+      var answerString = angular.toJson(submission);
+      console.log(answerString);
+      clmDataStore.events.submitSolution(eventId, taskId, participant.$id, answerString)
+          .then(
+              clmDataStore.events.saveScore(eventId, participant.$id, taskId, score)
+          ).then(
+          $location.path(urlFor('oneEvent',{eventId: eventId}))
+      );
   }
 
   console.log(self.questions);
@@ -263,6 +263,19 @@ export function startMcqController(initialData, challengeService, clmDataStore, 
       question.answers.push(itemIndex);
     }
     console.log(question.answers);
+
+    checkMCQValid();
+  }
+
+  function checkMCQValid(){
+    for (var i = 0; i < self.questions.length; i ++){
+      if(self.questions[i].answers.length == 0){
+        self.isMcqValid = false;
+
+        return;
+      }
+    }
+    self.isMcqValid = true;
   }
 
   self.discardChanges = function (ev){
@@ -295,8 +308,6 @@ startMcqController.$inject = [
 
 export function newMcqController(initialData, challengeService, $filter,$mdDialog,urlFor,$location){
   var self = this;
-
-  console.log("the initial new data is........", initialData);
 
   // Checks if all questions have at least one answer
   self.isMcqValid = false;

--- a/src/classmentors/components/challenges/mcq/mcq.js
+++ b/src/classmentors/components/challenges/mcq/mcq.js
@@ -277,7 +277,7 @@ export function startMcqController(initialData, challengeService, clmDataStore, 
       // decided to discard data, bring user to previous page
 
       //todo: link back to previous page
-      $location.path(urlFor('oneEvent', {eventId: initialData.event.$id}));
+      $location.path(urlFor('oneEvent', {eventId: eventId}));
 
     })
   }

--- a/src/classmentors/components/events/events-view-event-table-participants.html
+++ b/src/classmentors/components/events/events-view-event-table-participants.html
@@ -83,6 +83,7 @@
                                         <!--<span ng-switch-default>Start challenge</span>-->
                                     <!--</span>-->
                                 </md-button>
+                            </span>
                         </div>
 
                         <div ng-if="task.serviceId">

--- a/src/classmentors/components/events/events-view-event-table-participants.html
+++ b/src/classmentors/components/events/events-view-event-table-participants.html
@@ -56,7 +56,7 @@
                             <span ng-if="ctrl.currentUserSolutions[task.$id]">
 
                                 <!--todo: add timer and make it work-->
-                                <timer countdown = "10041" max-time-unit="minute" interval="1000"> {{mminutes}} minute {{minutesS}},{{sseconds}} second{{secondsS}}</timer>
+                                <!--<timer countdown = "10041" max-time-unit="minute" interval="1000"> {{mminutes}} minute {{minutesS}},{{sseconds}} second{{secondsS}}</timer>-->
                                 <span ng-if="!ctrl.currentUserProgress[task.$id].completed"></span>
 
                                 <md-button class="md-raised md-primary"

--- a/src/classmentors/components/events/events-view-event-table-participants.html
+++ b/src/classmentors/components/events/events-view-event-table-participants.html
@@ -54,7 +54,21 @@
                     <td ng-repeat="task in ctrl.visibleTasks track by task.$id">
                         <div ng-if="task.mcqQuestions">
                             <span ng-if="ctrl.currentUserSolutions[task.$id]">
-                                Completed<span ng-if="!ctrl.currentUserProgress[task.$id].completed"></span>
+
+                                <!--todo: add timer and make it work-->
+                                <timer countdown = "10041" max-time-unit="minute" interval="1000"> {{mminutes}} minute {{minutesS}},{{sseconds}} second{{secondsS}}</timer>
+                                <span ng-if="!ctrl.currentUserProgress[task.$id].completed"></span>
+
+                                <md-button class="md-raised md-primary"
+                                           ng-click="ctrl.startMCQ(ctrl.event.$id, task.$id, task, ctrl.currentUserParticipant, ctrl.currentUserSolutions)"
+                                           target="_blank"
+                                           ng-if="task.openedAt"
+                                           aria-label="Re-attempt challenge"
+                                >
+
+                                Re-attempt Mcq
+                                </md-button>
+
                             </span>
                             <span ng-if="!ctrl.currentUserSolutions[task.$id]">
                                 <md-button class="md-raised md-primary"
@@ -63,7 +77,7 @@
                                            ng-disabled="task.closedAt"
                                            aria-label="Start challenge"
                                 >
-                                    start mcq
+                                    Start Mcq
                                     <!--<span ng-switch on="ctrl.mustRegister(task, ctrl.profile)">-->
                                         <!--<span ng-switch-when="true">Register</span>-->
                                         <!--<span ng-switch-default>Start challenge</span>-->

--- a/src/classmentors/components/events/events-view-event-table-participants.html
+++ b/src/classmentors/components/events/events-view-event-table-participants.html
@@ -55,19 +55,19 @@
                         <div ng-if="task.mcqQuestions">
                             <span ng-if="ctrl.currentUserSolutions[task.$id]">
 
-                                <!--todo: add timer and make it work-->
+                                <!--todo: add timer and make it work before allowing re-attempts-->
                                 <!--<timer countdown = "10041" max-time-unit="minute" interval="1000"> {{mminutes}} minute {{minutesS}},{{sseconds}} second{{secondsS}}</timer>-->
-                                <span ng-if="!ctrl.currentUserProgress[task.$id].completed"></span>
+                                Completed<span ng-if="!ctrl.currentUserProgress[task.$id].completed"></span>
 
-                                <md-button class="md-raised md-primary"
-                                           ng-click="ctrl.startMCQ(ctrl.event.$id, task.$id, task, ctrl.currentUserParticipant, ctrl.currentUserSolutions)"
-                                           target="_blank"
-                                           ng-if="task.openedAt"
-                                           aria-label="Re-attempt challenge"
-                                >
+                                <!--<md-button class="md-raised md-primary"-->
+                                           <!--ng-click="ctrl.startMCQ(ctrl.event.$id, task.$id, task, ctrl.currentUserParticipant, ctrl.currentUserSolutions)"-->
+                                           <!--target="_blank"-->
+                                           <!--ng-if="task.openedAt"-->
+                                           <!--aria-label="Re-attempt challenge"-->
+                                <!--&gt;-->
 
-                                Re-attempt Mcq
-                                </md-button>
+                                <!--Re-attempt Mcq-->
+                                <!--</md-button>-->
 
                             </span>
                             <span ng-if="!ctrl.currentUserSolutions[task.$id]">


### PR DESCRIPTION
1.Added codes for allowing re-attempt of MCQ [currently disabled]

Removed fields in mcq-new, mcq-edit:
2.1. time limit (will be re-intro in later stage)
2.2. randomise questions and options (will be re-intro in later stage)
2.3. release result waiting time
2.4. re-attempts after n minutes (will be re-intro in later stage)

fixed locationpath error for cancel button when student attempt mcq

disabled students from submitting blank mcq answers.